### PR TITLE
Remove version_info check from CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -197,8 +197,6 @@ jobs:
         run: pip install -e .
       - name: Assert is importable, show version
         run: python -c "import sphinx_wagtail_theme; print(sphinx_wagtail_theme.__version__)"
-      - name: Assert is importable and show version_info
-        run: python -c "import sphinx_wagtail_theme; print(sphinx_wagtail_theme.version_info)"
       - run: pytest
       - name: make test TODO Make this work
         if: 0


### PR DESCRIPTION
It fails because `version_info` is no longer defined in `__init__.py`. I'm assuming it's
safe to remove this check from CI as it appears to only be a sanity check.

We can always put it back in there if it turns out to be important :slightly_smiling_face: 