### PR TITLE
Fix: Broken layout on RST pages

### DIFF
--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -111,7 +111,7 @@
                     </div>
                 </div>
             </aside>
-            <main class="col pt-5">
+            <main class="col-12 col-lg-9 pt-5">
                 <header class="row align-items-baseline">
                     <div class="col">
                         {% include "breadcrumbs.html" %}
@@ -128,7 +128,7 @@
                     </div>
                 </div>
                 <div class="row">
-                    <article class="col order-last order-lg-first">
+                    <article class="col-12 col-lg-9 order-last order-lg-first">
                         {%- block body %}
                         {% endblock -%}
                         {% include "pager.html" %}


### PR DESCRIPTION
The automatic with `col` did not work quite right on pages generated from RST.
I am not sure why, but defining the col widths explicitly solves the issue.

For what it's worth, I also think it looks better and seems to behave nicer
and more predictable on other pages too.


Closes #69 