### PR TITLE
GitHub url

### DIFF
--- a/sphinx_wagtail_theme/source-buttons.html
+++ b/sphinx_wagtail_theme/source-buttons.html
@@ -1,36 +1,8 @@
 <div>
-    {%- if theme_github_repository and theme_github_branch %}
-        {%- if theme_github_sphinx_locale %}
-            {%- set localizationprefix = "Localization." + theme_github_sphinx_locale + "/" %}
-        {%- else %}
-            {%- set localizationprefix = "" %}
-        {%- endif %}
-
-        {%- if theme_path_to_documentation_dir %}
-            <a class="btn btn-sm btn-light" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/{{ theme_path_to_documentation_dir|e }}/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank">
-                <span class="btn-icon"><span class="fab fa-github"></span></span>
-                <span class="btn-text">Edit on GitHub</span>
-            </a>
-        {%- else %}
-            <a class="btn btn-sm btn-light" href="https://github.com/{{ theme_github_repository|e }}/edit/{{ theme_github_branch|e }}/Documentation/{{ localizationprefix|e }}{{ sourcename|replace('.txt', '.rst')|replace('.rst.rst', '.rst')|e }}" target="_blank">
-                <span class="btn-icon"><span class="fab fa-github"></span></span>
-                <span class="btn-text">Edit on GitHub</span>
-            </a>
-        {%- endif %}
-    {%- elif display_github and builder == 'html' %}
-        <a class="btn btn-sm btn-light" href="https://{{ github_host|default("github.com") }}/{{ github_user }}/{{ github_repo }}/blob/{{ github_version }}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}">
+    {%- if theme_github_url %}
+        <a class="btn btn-sm btn-light" href="{{ theme_github_url }}{{ pagename }}{{ page_source_suffix }}" rel="nofollow">
             <span class="btn-icon"><span class="fab fa-github"></span></span>
-            <span class="btn-text">Edit on GitHub</span>
-        </a>
-    {%- elif display_bitbucket and builder == 'html' %}
-        <a class="btn btn-sm btn-light" href="https://bitbucket.org/{{ bitbucket_user }}/{{ bitbucket_repo }}/src/{{ bitbucket_version}}{{ conf_py_path }}{{ pagename }}{{ source_suffix }}">
-            <span class="btn-icon"><span class="fab fa-bitbucket"></span></span>
-            <span class="btn-text">Edit on Bitbucket</span>
-        </a>
-    {%- elif show_source and source_url_prefix %}
-        <a class="btn btn-sm btn-light" href="{{ source_url_prefix }}{{ pagename }}{{ source_suffix }}">
-            <span class="btn-icon"><span class="fas fa-code"></span></span>
-            <span class="btn-text">View source</span>
+            <span class="btn-text">{{ _('Edit on GitHub') }}</span>
         </a>
     {%- endif %}
     {%- if show_source and has_source and sourcename %}

--- a/sphinx_wagtail_theme/theme.conf
+++ b/sphinx_wagtail_theme/theme.conf
@@ -32,3 +32,4 @@ logo_width = 45
 #
 header_links = Features|https://wagtail.io/features/, About Wagtail|https://wagtail.io/about-wagtail/, Services|https://wagtail.io/services/, Blog|https://wagtail.io/blog/, Packages|https://wagtail.io/packages/, Developers|https://wagtail.io/developers/
 footer_links = Features|https://wagtail.io/features/, About Wagtail|https://wagtail.io/about-wagtail/, Services|https://wagtail.io/services/, Blog|https://wagtail.io/blog/, Packages|https://wagtail.io/packages/, Developers|https://wagtail.io/developers/
+github_url = https://github.com/wagtail/wagtail/blob/main/docs/

--- a/sphinx_wagtail_theme/theme.conf
+++ b/sphinx_wagtail_theme/theme.conf
@@ -4,32 +4,13 @@ stylesheet = dist/theme.css
 pygments_style = none
 
 [options]
-version = unknown_version
-github_branch = unused, deprecated
-github_commit_hash = unused, deprecated
-github_repository = unused, deprecated
-github_revision_msg = unused, deprecated
-github_sphinx_locale = unused, deprecated
 is_homepage =
-path_to_documentation_dir = Documentation
 project_name = Sphinx Wagtail Theme
-show_copyright = recommended
-# show_last_modified prints: Last updated
-show_last_modified = recommended
-# show_last_updated prints: Last rendered
-show_last_updated = recommended
-show_legalinfo =
-show_revision =
-show_sourcelink = recommended
-show_sphinx =
-use_opensearch =
-#
 logo = img/wagtail-logo-new.svg
 logo_alt = Wagtail
 logo_height = 59
 logo_url = /
 logo_width = 45
-#
-header_links = Features|https://wagtail.io/features/, About Wagtail|https://wagtail.io/about-wagtail/, Services|https://wagtail.io/services/, Blog|https://wagtail.io/blog/, Packages|https://wagtail.io/packages/, Developers|https://wagtail.io/developers/
+header_links =
 footer_links = Features|https://wagtail.io/features/, About Wagtail|https://wagtail.io/about-wagtail/, Services|https://wagtail.io/services/, Blog|https://wagtail.io/blog/, Packages|https://wagtail.io/packages/, Developers|https://wagtail.io/developers/
-github_url = https://github.com/wagtail/wagtail/blob/main/docs/
+github_url = https://github.com/wagtail/sphinx_wagtail_theme/blob/main/docs/


### PR DESCRIPTION
This simplifies the Github button. It now will always point to main branch.
I figured that if someone wanted to suggest changes, main is the source we accept pull requests against.
Maybe not the most advanced, but works TM.

I also stripped all redundant theme variables.