### PR TITLE
Pin Sphinx version to match Read the Docs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,10 +3,11 @@ flake8
 pip
 pytest
 setuptools
-sphinx
+# Pin sphinx to the version used by read the docs: https://docs.readthedocs.io/en/stable/intro/import-guide.html#building-your-documentation
+sphinx==1.8.5
 recommonmark
 twine
 wheel
 zest.releaser
 # Pin because of https://github.com/readthedocs/recommonmark/issues/220
-docutils==0.16 
+docutils==0.16


### PR DESCRIPTION
Read the docs always uses Sphinx version 1.8.5. To make sure that the
development works with the same constraints as the production hosting,
the version is pinned.

https://docs.readthedocs.io/en/stable/intro/import-guide.html#building-your-documentation

Closes #25 