### PR TITLE
Display theme version in source

### DIFF
--- a/sphinx_wagtail_theme/footer.html
+++ b/sphinx_wagtail_theme/footer.html
@@ -14,9 +14,9 @@
                 {%- if theme_show_last_updated and last_updated %}
                 <p>Last rendered: {{ last_updated|e }}</p>
                 {%- endif %}
-                <p>
+                <p style="display: none">
                     <a class="text-light" href="https://github.com/wagtail/sphinx_wagtail_theme" rel="nofollow" target="_blank">
-                        {{ theme_project_name }} {{ theme_version|e }}
+                        Wagtail Sphinx Theme {{ theme_version|e }}
                     </a>
                 </p>
             </div>


### PR DESCRIPTION
Quick fix.

The footer line is mixing theme and project data.
I made it the theme version. But I've also hidden it, as it is irrelevant/confusing for most Wagtail docs visitors.

Note, the correct version is in the version picker.
Note, we might do this better in the future. For now, I'd like to get the work into Wagtail main.