### PR TITLE
Fix some simple accessibility issues

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -23,7 +23,7 @@ This is for local testing purposes only.
             {# Add `shift-up` class for expanded style #}
             class="rst-versions"
             data-toggle="rst-versions"
-            role="note"
+            role="navigation"
             aria-label="versions"
         >
             <span class="rst-current-version" data-toggle="rst-current-version">
@@ -236,6 +236,7 @@ This is for local testing purposes only.
                                         type="text"
                                         name="q"
                                         placeholder="Search docs"
+                                        aria-label="Search docs"
                                     />
                                 </form>
                             </div>

--- a/sass/_component_header.scss
+++ b/sass/_component_header.scss
@@ -1,14 +1,33 @@
 header {
-	.navbar {
-		a {
-			border: none;
-		}
-	}
-
+    > .container-fluid {
+        padding: 0;
+    }
+    .navbar {
+        padding: 0.75rem 0;
+        flex-wrap: unset;
+    }
     .navbar-brand {
+        display: flex;
+        padding: 0;
+        border: none;
+        margin-right: 0;
         font-size: $h3-font-size;
+        line-height: 1.2;
+        white-space: unset;
+        align-items: center;
+        justify-content: space-between;
+    }
+    .logo-img {
+        flex-shrink: 0;
+        margin-right: 0.75rem;
+        // The lines below are an adjustment to compensate for the way the brand typeface baseline sits a bit too high.
+        position: relative;
+        top: -1px;
     }
     .navbar-dark .navbar-nav .nav-link {
         color: $link-alternate-color;
+    }
+    .navbar-toggler-text {
+        @include sr-only;
     }
 }

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -36,7 +36,7 @@ $yiq-contrasted-threshold: 160;
 //
 // Code Colors
 // --------------------------------------------------
-$code-color:        #ff5370;
+$code-color:        #ee0028;
 $code-color-file:   hsl(328, 100%, 50%);
 $code-color-html:   hsl(275, 100%, 40%);
 $code-color-js:     hsl(128, 100%, 20%);

--- a/sphinx_wagtail_theme/footer.html
+++ b/sphinx_wagtail_theme/footer.html
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col p-4">
             {% if theme_footer_links %}
-                <nav>
+                <nav aria-label="Footer navigation">
                     <ul class="nav justify-content-center mb-2">
                         {% for link in theme_footer_links.split(',') %}
                             {% set link_text=link.split("|")[0] %}

--- a/sphinx_wagtail_theme/footer.html
+++ b/sphinx_wagtail_theme/footer.html
@@ -2,7 +2,7 @@
     <div class="row">
         <div class="col p-4">
             {% if theme_footer_links %}
-                <nav aria-label="Footer navigation">
+                <nav aria-label="Footer">
                     <ul class="nav justify-content-center mb-2">
                         {% for link in theme_footer_links.split(',') %}
                             {% set link_text=link.split("|")[0] %}

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -66,7 +66,7 @@
 <body>
     <header class="container-fluid bg-primary">
         <div class="container-fluid">
-            <nav class="navbar navbar-expand-lg navbar-dark font-weight-bold px-0">
+            <div class="navbar navbar-expand-lg navbar-dark font-weight-bold">
                 {%- if theme_logo and theme_logo != 'None' %}
                     <a href="{{ theme_logo_url }}"
                         {% if theme_logo_alt %}title="{{ theme_logo_alt|e }}"{% endif %}
@@ -77,7 +77,7 @@
                             {%- if theme_logo_height %} height="{{ theme_logo_height|e }}"{% endif %}
                             {%- if theme_logo_alt %} alt="{{ theme_logo_alt|e }}"{% endif %}
                             {%- if theme_logo_title and not theme_logo_url %} title="{{ theme_logo_title|e }}"{% endif %}
-                            class="d-inline-block mr-2"
+                            class="logo-img"
                         />
                         {{ theme_project_name }}
                     </a>
@@ -93,10 +93,11 @@
                         </ul>
                     </div>
                 {% endif %}
-                <button class="btn btn-primary d-lg-none" type="button" data-toggle="collapse" data-target="#collapseSidebar" aria-expanded="false" aria-controls="collapseExample">
+                <button class="navbar-toggler btn btn-primary d-lg-none" type="button" data-toggle="collapse" data-target="#collapseSidebar" aria-expanded="false" aria-controls="collapseExample">
                     <span class="navbar-toggler-icon"></span>
+                    <span class="navbar-toggler-text">Menu</span>
                 </button>
-            </nav>
+            </div>
         </div>
     </header>
     <div class="container-fluid">

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -107,7 +107,7 @@
                         {%- include "searchbox.html" %}
                     {%- endif %}
                     <div class="site-toc">
-                        <nav class="toc mt-3">
+                        <nav class="toc mt-3" aria-label="Main menu">
                             {%- set toctree = toctree(maxdepth=8, collapse=False, includehidden=False, titles_only=True) -%}
                             {%- if toctree %}
                                 {{ toctree }}
@@ -142,8 +142,8 @@
                         {% include "pager.html" %}
                     </article>
                     {% if display_toc and not hidetoc %}
-                        <nav class="col-12 col-lg-3 pb-4 toc page-toc">
-                            <p class="font-weight-bold">Page contents</p>
+                        <nav class="col-12 col-lg-3 pb-4 toc page-toc" aria-labelledby="page-toc-heading">
+                            <p class="font-weight-bold" id="page-toc-heading">Page contents</p>
                             {{ toc }}
                         </nav>
                     {% endif %}


### PR DESCRIPTION
These changes fix (most of*) the errors reported by the WAVE and Axe browser-based accessibility testing tools. Fortunately, there were few!

_* Not fixed in this PR: Axe reports an issue with the search autocomplete box not having an ARIA role when it appears. Taking a look at the source of the autocompleter npm package that we use for this, there is not a simple fix. I also would like to do some manual testing on it to make sure it can be used with a keyboard only and is properly announced by a screen reader._

This also fixes #103, reworking the way that the header is laid out so that on mobile devices the menu button will stay to the right and the site title will break to multiple lines if necessary.

Before | After
----- | -----
![Current site with menu button below title](https://user-images.githubusercontent.com/1044670/123124592-a944a680-d3fc-11eb-9f81-8b2cf5738dd3.png) | ![Proposed change with site title on two lines and menu button on the right](https://user-images.githubusercontent.com/1044670/123124960-f6287d00-d3fc-11eb-8b03-22c12829d859.png)

