### PR TITLE
Don't load webfonts.css since it's been removed and 404s.

### DIFF
--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -35,7 +35,6 @@
         <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}" />
     {%- endif %}
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/' + style, 1) }}" />
-    <link rel="stylesheet" type="text/css" href="{{ pathto('_static/dist/webfonts.css', 1) }}" />
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/dist/fontawesome.css', 1) }}" />
     {%- block linktags %}
         {%- if hasdoc('about') %}


### PR DESCRIPTION
I noticed a 404/warning about not using a CSS file since it's mimetype was HTML while browsing the main documentation site. It appears to me that this `<link>` tag should be removed from the main `layout.html`.

In 928623c838f4854d the file itself was removed and the reference to it was removed in 91ec36ec8e1e8f23 but reintroduced in cd84f55eca2f0e9a.