### PR TITLE
Use language specified by sphinx config in html tag

### DIFF
--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -17,7 +17,7 @@
     {%- endif %}
 {%- endif %}
 <!DOCTYPE html>
-<html class="no-js" lang="en">
+<html class="no-js" {% if language is not none %}lang="{{ language }}"{% endif %}>
 <head>
     <meta charset="utf-8" />
     {%- if metatags %}


### PR DESCRIPTION
Sphinx has a config value named `language`, which should be used to set the language on the `<html>` tag. (All built-in themes/templates work this way). Currently this theme hard-codes the language to `en` in the HTML template.

This `language` setting is used for other purposes as well, such as loading different translated images, using the correct grammar (e.g. English vs French quotation marks, etc.), so it is an integral part of Sphinx.

One slight backwards-incompatible change: any projects using `sphinx_wagtail_theme` should set `language='en'` in their `conf.py`, otherwise no language will be specified in the HTML tag.

See: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-language

See: https://github.com/sphinx-doc/sphinx/blob/9e1b4a8f1678e26670d34765e74edf3a3be3c62c/sphinx/themes/basic/layout.html#L107

Also related to #108 