### PR TITLE
Use <main> element to match role=main area of body content

### DIFF
--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -119,7 +119,7 @@
                     </div>
                 </div>
             </aside>
-            <main class="col-12 col-lg-9 pt-5">
+            <div class="col-12 col-lg-9 pt-5">
                 <header class="row align-items-baseline">
                     <div class="col">
                         {% include "breadcrumbs.html" %}
@@ -136,11 +136,11 @@
                     </div>
                 </div>
                 <div class="row">
-                    <article class="col-12 col-lg-9 order-last order-lg-first" role="main">
+                    <main class="col-12 col-lg-9 order-last order-lg-first" role="main">
                         {%- block body %}
                         {% endblock -%}
                         {% include "pager.html" %}
-                    </article>
+                    </main>
                     {% if display_toc and not hidetoc %}
                         <nav class="col-12 col-lg-3 pb-4 toc page-toc" aria-labelledby="page-toc-heading">
                             <p class="font-weight-bold" id="page-toc-heading">Page contents</p>
@@ -148,7 +148,7 @@
                         </nav>
                     {% endif %}
                 </div>
-            </main>
+            </div>
         </div>
     </div>
     <footer class="container-fluid bg-primary text-light">


### PR DESCRIPTION
See discussion in #113 . What do you think of this instead @Scotchester ?

Tested both before and after this change in various browsers and using the Windows narrator. Does not seem to be any visual or audible change.

I think use of these new HTML 5 elements seems to be splitting hairs in some places (i.e. difference between a `<main>` and an `<article>` element). However from researching MDN this current structure seems to be perfectly "legal" and make sense. Main is used for the actual page content (if you were to have a "skip to main content" button, it would jump here). Main can also contain headings, sections, paragraphs, etc.

Following this logic... sphinx looks for `role="main"` on page elements to determine what to index in its JavaScript-based search. So I don't think we'd want the breadcrumbs and "Edit on GitHub" buttons being indexed.