### PR TITLE
Increase contrast of admonitions to WCAG AAA, inline code to AA

### DIFF
--- a/docs/examples/admonitions.md
+++ b/docs/examples/admonitions.md
@@ -28,6 +28,9 @@
 ```eval_rst note:: Notes can provide complementary information.
 ```
 
+```eval_rst seealso:: The world is your oyster.
+```
+
 ```eval_rst tip:: Speak softly and carry a big stick; you will go far.
 ```
 

--- a/sass/_component_admotion.scss
+++ b/sass/_component_admotion.scss
@@ -8,7 +8,7 @@
 // - Horizontal Buttons
 //
 .admonition {
-    background-color: theme-color-level('dark', -11);
+    background-color: theme-color-level('info', -11);
     margin: $spacer 0;
     padding: $spacer;
     box-shadow: $box-shadow-sm;
@@ -23,8 +23,9 @@
     padding: ($spacer / 2) $spacer;
     margin: -$spacer;
     margin-bottom: $spacer;
-    color: color-yiq(theme-color('dark'));
-    background-color: theme-color('dark');
+    color: color-yiq(theme-color('info'));
+    background-color: theme-color('info');
+    font-weight: $font-weight-bold;
     &:before {
         @include fa-icon;
         content: fa-content($fa-var-info-circle);

--- a/sass/_component_version.scss
+++ b/sass/_component_version.scss
@@ -15,6 +15,7 @@
     padding: ($spacer / 2) $spacer;
     margin: -$spacer;
     margin-bottom: $spacer;
+    font-weight: $font-weight-bold;
     &:before {
         @include fa-icon;
         font-family: 'Font Awesome 5 Free';
@@ -23,10 +24,10 @@
     }
 }
 .versionadded {
-    background-color: theme-color-level('info', -11);
+    background-color: theme-color-level('success', -11);
     .versionmodified {
-        color: color-yiq(theme-color('info'));
-        background-color: theme-color('info');
+        color: color-yiq(theme-color('success'));
+        background-color: theme-color('success');
         &:before {
             content: fa-content($fa-var-info-circle);
         }

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -17,10 +17,10 @@ $indigo:            #251657;
 $bright-green: 		#3beccd;
 
 $primary:           $indigo;
-$success:           #5cb85c;
-$info:              #5bc0de;
+$success:           #006363;
+$info:              #3f428b;
 $warning:           #f0ad4e;
-$danger:            #d9534f;
+$danger:            #a72925;
 
 
 $link-color: $primary;
@@ -36,7 +36,7 @@ $yiq-contrasted-threshold: 160;
 //
 // Code Colors
 // --------------------------------------------------
-$code-color:        #ee0028;
+$code-color:        $danger;
 $code-color-file:   hsl(328, 100%, 50%);
 $code-color-html:   hsl(275, 100%, 40%);
 $code-color-js:     hsl(128, 100%, 20%);

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -36,7 +36,7 @@ $yiq-contrasted-threshold: 160;
 //
 // Code Colors
 // --------------------------------------------------
-$code-color:        #ee0028;
+$code-color:        #d02040;
 $code-color-file:   hsl(328, 100%, 50%);
 $code-color-html:   hsl(275, 100%, 40%);
 $code-color-js:     hsl(128, 100%, 20%);

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -36,7 +36,7 @@ $yiq-contrasted-threshold: 160;
 //
 // Code Colors
 // --------------------------------------------------
-$code-color:        $danger;
+$code-color:        #ee0028;
 $code-color-file:   hsl(328, 100%, 50%);
 $code-color-html:   hsl(275, 100%, 40%);
 $code-color-js:     hsl(128, 100%, 20%);


### PR DESCRIPTION
Fixes #11 , also see discussion on #119 

Color contrast of admonitions, version notices meets **WCAG AAA** standard. Inline code contrast has also been increased slightly to meet **WCAG AA** standard (is now 5.3:1), plus also meets 3:1 contrast ratio with surrounding text.

Overall the new colors are not as "shiny" but hopefully still match the look-and-feel. More shininess can be had if we are OK with lowering to WCAG AA standard.

Kept the colors mostly the same:
* Info was changed to a more indigo-ish color to match the theme;
* Success was changed to a more wagtail-ish teal.
* Danger was darkened.
* Default admonition was black, changed this to info, to better match theme.
* Warning was already good, no changes.
* Made admonition titles bold.
* Inline code was previously a bright red, adjusted slightly to increase contrast while preserving color contrast with color of surrounding text (blackish gray).

### Admonitions:

![image](https://user-images.githubusercontent.com/13453401/142929009-e28cbad8-f3fe-4522-8c81-aabe03d76941.png)

### Versions:

![image](https://user-images.githubusercontent.com/13453401/142929087-1cfe8877-5d5b-4331-a15b-4ae1cc6dee3d.png)

### Inline code:

![image](https://user-images.githubusercontent.com/13453401/142929185-e0a07a8c-0763-43ac-b07a-e6675fa61927.png)
