### PR TITLE
Autocomplete improvements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,8 +5,8 @@ History
 5.0.5 (unreleased)
 ==================
 
-- Nothing changed yet.
-
+- Feature: massively improved autocomplete (`#123 <https://github.com/wagtail/sphinx_wagtail_theme/pull/123>`_).
+- Clean-up: remove unused Typo3 version selector code (`#123 <https://github.com/wagtail/sphinx_wagtail_theme/pull/123>`_).
 
 5.0.4 (2021-06-28)
 ==================

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,6 +1,7 @@
 // T3Docs
 import '../sass/theme.scss';
 import autocomplete from 'autocompleter'
+import 'bootstrap';
 
 // Ensure our own namespace
 if (typeof window.T3Docs === 'undefined') {

--- a/js/theme.js
+++ b/js/theme.js
@@ -78,14 +78,6 @@ document.addEventListener('DOMContentLoaded', function () {
               });
             });
           });
-          // Add terms third (they are not necessarily real words, but stems of
-          // words used by the search algorithm, so are minimally helpful).
-          Object.keys(Search._index.terms).forEach(function (item) {
-            window.T3Docs.autocomplete.push({
-              label: item,
-              group: "Suggested term"
-            });
-          });
         }
         var suggestions = window.T3Docs.autocomplete.filter(function (entry) {
           return entry.label.toLowerCase().includes(text.toLowerCase());

--- a/sass/_component_search.scss
+++ b/sass/_component_search.scss
@@ -29,8 +29,19 @@
         background-color: $gray-100;
     }
     .selected {
-        color: color-yiq($yellow);
-        background-color: $yellow;
+        color: color-yiq($search);
+        background-color: $search;
+    }
+    .selected::after {
+        border-radius: $border-radius;
+        border: 1px solid color-yiq($search);
+        content: "Enter ↵";
+        float: right;
+        font-size: 0.75em;
+        line-height: 1;
+        padding: $input-padding-y/2 $input-padding-x/2;
+        margin-top: $input-padding-y/2;
+        margin-left: $input-padding-x/2;
     }
 }
 
@@ -38,8 +49,8 @@
  * Highlight
  */
 .highlighted {
-    color: color-yiq($yellow) !important;
-    background-color: $yellow !important;
+    color: color-yiq($search) !important;
+    background-color: $search !important;
 }
 
 /**

--- a/sass/_component_search.scss
+++ b/sass/_component_search.scss
@@ -23,9 +23,14 @@
             cursor: pointer;
         }
     }
+    .group {
+        font-weight: $font-weight-bold;
+        font-size: 0.85em;
+        background-color: $gray-100;
+    }
     .selected {
-        color: color-yiq(theme-color('primary'));
-        background-color: theme-color('primary');
+        color: color-yiq($yellow);
+        background-color: $yellow;
     }
 }
 

--- a/sass/_component_search.scss
+++ b/sass/_component_search.scss
@@ -16,6 +16,7 @@
     background-clip: padding-box;
     border: $input-border-width solid $input-border-color;
     box-shadow: $box-shadow-sm;
+    z-index: 10000;
     > div {
         padding: $input-padding-y $input-padding-x;
         &:not(.empty) {

--- a/sass/_component_search.scss
+++ b/sass/_component_search.scss
@@ -72,7 +72,7 @@
     }
     a {
         @include font-size($h4-font-size);
-        display: block;
+        display: inline-block;
         margin-bottom: $headings-margin-bottom;
         font-family: $headings-font-family;
         font-weight: $headings-font-weight;

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -21,6 +21,7 @@ $success:           #006363;
 $info:              #3f428b;
 $warning:           #f0ad4e;
 $danger:            #a72925;
+$search:            #ffe69c;
 
 
 $link-color: $primary;


### PR DESCRIPTION
Autocomplete currently shows behind the nav, which makes it quite unreadable. I also noticed that the suggestions are not actually human words. Further investigation reveals that they are using Sphinx's stemmed words. So I did a bit of work here to improve the search suggestions:
* Add enough z-index to put autocomplete in front of other elements.
* Removed the "no elements found message" - found this to be a bit discouraging (as in, there will not be any search results for what you have typed; when in reality there ARE some search results).
* Suggest in the following order:
  * Page titles (selecting goes directly to the page, bypassing search)
  * code/autodoc objects
  * stemmed words

Also removed some unused jquery code from the theme js, which looked like a customized version selector for T3 (clearly we don't need to be making ajax calls to T3's docs). The element ID being acted on does not actually exist in our template anyhow.

Since Wagtail itself uses algolia, I don't think anyone was actually using any of this stuff. But now it should hopefully be usable.

Before:

![image](https://user-images.githubusercontent.com/13453401/142925616-4e91d9e6-88e2-4b56-9c15-701272bc453c.png)

After:

![image](https://user-images.githubusercontent.com/13453401/142925489-3511523a-6f6d-434c-b311-85fceefa6309.png)

