### PR TITLE
Allow customizing sidebar

### DIFF
--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -105,7 +105,7 @@ relevant rules:
    /* Import from Google Fonts, a CDN, or files in your _static folder.
       This Google Fonts import provides its own `@font-face` CSS;
       if providing your own font files, you'll also need to
-      provide your own @font-face` code. */
+      provide your own `@font-face` code. */
    @import url("https://fonts.googleapis.com/css2?family=Roboto");
 
    /* Main font used throughout the docs. */
@@ -117,3 +117,33 @@ relevant rules:
    pre, code, kbd, samp {
      font-family: "Courier New", monospace;
    }
+
+Custom Sidebars
+---------------
+
+To add a custom sidebar (for example, add a link to sponsor your project),
+create a custom HTML template and specify it in ``conf.py``:
+
+.. code-block:: python
+
+   # Add any relative paths that contain templates.
+   templates_path = ["_templates"]
+
+   # Custom sidebar templates, must be a dictionary that maps document names
+   # to template names. The theme default is just searchbox and globaltoc.
+   html_sidebars = {"**": [
+       "searchbox.html",
+       "globaltoc.html",
+       "custom.html",    # Your template here
+   ]}
+
+Then in ``_templates/custom.html``:
+
+.. code-block:: html
+
+   <p>
+     Sponsor my project!
+     <a href="http://example.com">Here's the link</a>
+   </p>
+
+Read more about `Sidebars in Sphinx <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_sidebars>`_

--- a/docs/customizing.rst
+++ b/docs/customizing.rst
@@ -118,11 +118,12 @@ relevant rules:
      font-family: "Courier New", monospace;
    }
 
-Custom Sidebars
----------------
+Customize the Sidebar
+---------------------
 
-To add a custom sidebar (for example, add a link to sponsor your project),
-create a custom HTML template and specify it in ``conf.py``:
+To change the contents of the sidebar, create a custom HTML template and specify
+it in ``conf.py``. For example, let's add a link to sponsor your project below
+the table of contents tree:
 
 .. code-block:: python
 
@@ -130,7 +131,8 @@ create a custom HTML template and specify it in ``conf.py``:
    templates_path = ["_templates"]
 
    # Custom sidebar templates, must be a dictionary that maps document names
-   # to template names. The theme default is just searchbox and globaltoc.
+   # to template names. "**" will apply the templates to all pages.
+   # The theme default is just searchbox and globaltoc.
    html_sidebars = {"**": [
        "searchbox.html",
        "globaltoc.html",
@@ -146,4 +148,4 @@ Then in ``_templates/custom.html``:
      <a href="http://example.com">Here's the link</a>
    </p>
 
-Read more about `Sidebars in Sphinx <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_sidebars>`_
+Read more about `customizing the sidebar in Sphinx <https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_sidebars>`_

--- a/sphinx_wagtail_theme/globaltoc.html
+++ b/sphinx_wagtail_theme/globaltoc.html
@@ -1,0 +1,5 @@
+<div class="site-toc">
+    <nav class="toc mt-3" aria-label="Main menu">
+        {{ toctree(includehidden=False, collapse=False, maxdepth=8, titles_only=True) }}
+    </nav>
+</div>

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -110,17 +110,14 @@
         <div class="row">
             <aside class="col-12 col-lg-3">
                 <div id="collapseSidebar" class="collapse sticky-top d-lg-block pt-5">
-                    {%- if not theme_is_homepage and builder == 'html' %}
+                    {%- if sidebars != None %}
+                        {%- for sidebartemplate in sidebars %}
+                        {%- include sidebartemplate %}
+                        {%- endfor %}
+                    {%- else %}
                         {%- include "searchbox.html" %}
+                        {%- include "globaltoc.html" %}
                     {%- endif %}
-                    <div class="site-toc">
-                        <nav class="toc mt-3" aria-label="Main menu">
-                            {%- set toctree = toctree(maxdepth=8, collapse=False, includehidden=False, titles_only=True) -%}
-                            {%- if toctree %}
-                                {{ toctree }}
-                            {%- endif %}
-                        </nav>
-                    </div>
                     <div class="d-lg-none border-bottom">
                         {# Bottom border for mobile (above content, needs to be expanded.) #}
                     </div>

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -110,14 +110,9 @@
         <div class="row">
             <aside class="col-12 col-lg-3">
                 <div id="collapseSidebar" class="collapse sticky-top d-lg-block pt-5">
-                    {%- if sidebars != None %}
-                        {%- for sidebartemplate in sidebars %}
-                        {%- include sidebartemplate %}
-                        {%- endfor %}
-                    {%- else %}
-                        {%- include "searchbox.html" %}
-                        {%- include "globaltoc.html" %}
-                    {%- endif %}
+                    {%- for sidebartemplate in sidebars %}
+                    {%- include sidebartemplate %}
+                    {%- endfor %}
                     <div class="d-lg-none border-bottom">
                         {# Bottom border for mobile (above content, needs to be expanded.) #}
                     </div>

--- a/sphinx_wagtail_theme/theme.conf
+++ b/sphinx_wagtail_theme/theme.conf
@@ -1,5 +1,6 @@
 [theme]
 inherit = none
+sidebars = searchbox.html, globaltoc.html
 stylesheet = dist/theme.css
 pygments_style = none
 

--- a/sphinx_wagtail_theme/theme.conf
+++ b/sphinx_wagtail_theme/theme.conf
@@ -4,7 +4,6 @@ stylesheet = dist/theme.css
 pygments_style = none
 
 [options]
-is_homepage =
 project_name = Sphinx Wagtail Theme
 logo = img/wagtail-logo-new.svg
 logo_alt = Wagtail


### PR DESCRIPTION
* Move sidebar toc into globaltoc template
* Allow customizing sidebars per usual sphinx manner.
* Add customizing docs.
* Removed undocumented `is_homepage` theme option (which seemingly only disabled the search box?)

See: https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_sidebars