### PR TITLE
Sphinx v4 support: exclude pygments css from layout

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,6 @@ version = sphinx_wagtail_theme.__version__
 release = sphinx_wagtail_theme.__version__
 language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
-pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 today_fmt = '%Y-%m-%d %H:%M'

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -16,6 +16,7 @@
         {%- set hidetoc = meta.get('hidetoc') %}
     {%- endif %}
 {%- endif %}
+{%- set sphinx_version_info = sphinx_version.split('.') | map('int') | list -%}
 <!DOCTYPE html>
 <html class="no-js" {% if language is not none %}lang="{{ language }}"{% endif %}>
 <head>
@@ -34,14 +35,22 @@
     {%- if favicon %}
         <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}" />
     {%- endif %}
+
+    {#- Include our own stylesheets -#}
+    {%- if sphinx_version_info[0] < 4 %}
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/' + style, 1) }}" />
+    {%- endif %}
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/dist/fontawesome.css', 1) }}" />
+    {#- Include stylesheets from sphinx (e.g. user custom css #}
     {%- for css in css_files %}
+    {#- Block pygments css; we are manually including ours in theme.css instead #}
+    {%- if css not in ["_static/pygments.css"] %}
       {%- if css|attr("filename") %}
       {{ css_tag(css) }}
       {%- else %}
       <link rel="stylesheet" href="{{ pathto(css, 1)|e }}" type="text/css" />
       {%- endif %}
+    {%- endif %}
     {%- endfor %}
     {%- block linktags %}
         {%- if hasdoc('about') %}


### PR DESCRIPTION
Noticed a bug caused by my recent change of allowing the user's custom css... it was also pulling in pygments css file (sphinx>=4) which was causing style weirdness.

Blocking that file since our `theme.css` manually includes pygments styles instead.

Tested the build output on sphinx versions 1, 2, 3, 4 to ensure it looks good on all.