### PR TITLE
Chore: Fix build warnings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ version = sphinx_wagtail_theme.__version__
 # The full version, including alpha/beta/rc tags.
 release = sphinx_wagtail_theme.__version__
 language = None
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'requirements.txt']
 pygments_style = 'sphinx'
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False

--- a/docs/examples/links.md
+++ b/docs/examples/links.md
@@ -9,7 +9,7 @@ An [external link](https://wwww.example.com).
 
 ## Internal Links
 
-An [internal link to another document](/examples).
+An [internal link to another document](../examples/index).
 
 ## Reference Links
 
@@ -27,6 +27,6 @@ A [link to a reference](this_is_the_reference_point).
 
 ## Links Over Code
 
-When using inline `code` as the text for a [`link`](/) it is hard to see.
+When using inline `code` as the text for a [`link`](index) it is hard to see.
 
 Unless, we can take special care of that in the styling.

--- a/docs/examples/rst-page.rst
+++ b/docs/examples/rst-page.rst
@@ -1,10 +1,9 @@
-
 .. _model_recipes:
 
 Page in reStructuredText
 ========================
 
-This page is directly from the Wagtail docs. 
+This page is directly from the Wagtail docs.
 This page is included because as of now (April 2021), the Wagtail docs are not completely converted to Markdown.
 
 
@@ -202,7 +201,7 @@ Here, ``blog_entries.filter(tags__name=tag)`` follows the ``tags`` relation on `
 
 Iterating through ``page.tags.all`` will display each tag associated with ``page``, while the links back to the index make use of the filter option added to the ``BlogIndexPage`` model. A Django query could also use the ``tagged_items`` related name field to get ``BlogPage`` objects associated with a tag.
 
-The same approach can be used to add tagging to non-page models managed through :ref:`snippets` and :doc:`/reference/contrib/modeladmin/index`. In this case, the model must inherit from ``modelcluster.models.ClusterableModel`` to be compatible with ``ClusterTaggableManager``.
+The same approach can be used to add tagging to non-page models managed through :doc:`/index`. In this case, the model must inherit from ``modelcluster.models.ClusterableModel`` to be compatible with ``ClusterTaggableManager``.
 
 
 Custom tag models

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,7 +16,6 @@ Welcome to "Sphinx Wagtail theme" documentation!
    :maxdepth: 2
    :titlesonly:
 
-   readme
    installation
    usage
    customizing

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,7 +1,0 @@
-sphinx_wagtail_theme
-====================
-
-.. toctree::
-   :maxdepth: 4
-
-   sphinx_wagtail_theme


### PR DESCRIPTION
Various missing files, unreferenced files, broken links, etc. which were causing warnings when building the docs.