### PR TITLE
Fix appearance of links within code blocks

### DIFF
--- a/sass/_component_pygments.scss
+++ b/sass/_component_pygments.scss
@@ -75,4 +75,11 @@ pre {
     .gp { font-weight: $font-weight-bold; } /* Generic.Prompt */
     .gs { font-weight: $font-weight-bold; } /* Generic.Strong */
     .gu { font-weight: $font-weight-bold; } /* Generic.Subheading */
+
+    // Anchors within pre tag, e.g. from autodoc modules.
+    a {
+        color: $base16-base07;
+        &:hover, &:visited:hover { color: darken($base16-base07, 10%); }
+        &:visited { color: $base16-base07; }
+    }
 }


### PR DESCRIPTION
Links are still dark within code blocks, making them unreadable. This can happen from module reference generated from autodoc, e.g.

Before:

![image](https://user-images.githubusercontent.com/13453401/143176209-6a718ff0-1ff4-4cba-b540-38dac378ebbb.png)

After:

![image](https://user-images.githubusercontent.com/13453401/143176056-988b3a74-7eb4-4110-b5d5-ccef215a6d56.png)
