### PR TITLE
Change design of prev/next links

### DIFF
--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -143,16 +143,18 @@
                     </div>
                 </div>
                 <div class="row">
-                    <main class="col-12 col-lg-9 order-last order-lg-first" role="main">
-                        {%- block body %}
-                        {% endblock -%}
+                    <div class="col-12 col-lg-9 order-last order-lg-first">
+                        <main role="main">
+                            {%- block body %}
+                            {% endblock -%}
+                        </main>
                         {% include "pager.html" %}
-                    </main>
+                    </div>
                     {% if display_toc and not hidetoc %}
-                        <nav class="col-12 col-lg-3 pb-4 toc page-toc" aria-labelledby="page-toc-heading">
-                            <p class="font-weight-bold" id="page-toc-heading">Page contents</p>
-                            {{ toc }}
-                        </nav>
+                    <nav class="col-12 col-lg-3 pb-4 toc page-toc" aria-labelledby="page-toc-heading">
+                        <p class="font-weight-bold" id="page-toc-heading">Page contents</p>
+                        {{ toc }}
+                    </nav>
                     {% endif %}
                 </div>
             </div>

--- a/sphinx_wagtail_theme/pager.html
+++ b/sphinx_wagtail_theme/pager.html
@@ -1,22 +1,14 @@
 {% if next or prev -%}
-    <nav aria-label="Page navigation">
-        <ul class="pagination justify-content-center">
-            {%- if prev %}
-                <li class="page-item">
-                    <a class="page-link" href="{{ prev.link|e }}" title="Accesskey Alt(+Shift)+p">
-                        Previous
-                        <strong class="d-block">{{ prev.title }}</strong>
-                    </a>
-                </li>
-            {%- endif %}
-            {%- if next %}
-                <li class="page-item">
-                    <a class="page-link" href="{{ next.link|e }}" title="Accesskey Alt(+Shift)+n">
-                        Next
-                        <strong class="d-block">{{ next.title }}</strong>
-                    </a>
-                </li>
-            {% endif %}
-        </ul>
-    </nav>
+<nav aria-label="Page navigation" class="py-4 my-5 clearfix font-weight-bold border-top">
+    {%- if prev %}
+    <a class="float-left" href="{{ prev.link|e }}" title="{{ _('Previous') }}">
+        <span aria-hidden="true" class="mr-1">←</span> {{ prev.title }}
+    </a>
+    {%- endif %}
+    {%- if next %}
+    <a class="float-right" href="{{ next.link|e }}" title="{{ _('Next') }}">
+        {{ next.title }} <span aria-hidden="true" class="ml-1">→</span>
+    </a>
+    {%- endif %}
+</nav>
 {%- endif %}


### PR DESCRIPTION
Per discussion in #87 . Also moved the prev/next buttons out of the `<main>` element since they are navigational only.

Before:

![image](https://user-images.githubusercontent.com/13453401/143993298-28711113-8afd-4d66-b6a2-a0c896aff450.png)


After:

![image](https://user-images.githubusercontent.com/13453401/143993265-92e5259c-af28-400b-b6dd-2b46683c56c3.png)
