### PR TITLE
Ignore pyenv python-version file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ npm-debug.log
 venv/
 env/
 .env/
+.python-version


### PR DESCRIPTION
This file is helpful for local development but does not make much sense to share on a library.