### PR TITLE
fix - disable pygments theme to only use custom code block styling

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,7 @@ version = sphinx_wagtail_theme.__version__
 release = sphinx_wagtail_theme.__version__
 language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'requirements.txt']
-pygments_style = 'sphinx'
+pygments_style = None
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 today_fmt = '%Y-%m-%d %H:%M'


### PR DESCRIPTION
- see sphinx_wagtail_theme/theme.conf (already disabled there)
- this project has its own pygments styling to suit the code block colours
- see https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-pygments_style
- fixes #147

### Screenshot

Left - current, Right - with config change

<img width="1975" alt="Screen Shot 2022-04-07 at 8 31 37 am" src="https://user-images.githubusercontent.com/1396140/162083230-593cfb7b-aef9-47cb-84f9-c665d9edd670.png">

