### PR TITLE
Fix pygments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [5.1.1] - YYYY-MM-DD
 
-Nothing new yet.
+### Fixed
+
+-   Fix code highlight, exclude pygments css from layout ([#154](https://github.com/wagtail/sphinx_wagtail_theme/pull/154))
 
 ## [5.1.0] - 2022-04-07
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,6 @@ version = sphinx_wagtail_theme.__version__
 release = sphinx_wagtail_theme.__version__
 language = None
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'requirements.txt']
-pygments_style = None
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 today_fmt = '%Y-%m-%d %H:%M'

--- a/docs/examples/rst-page.rst
+++ b/docs/examples/rst-page.rst
@@ -14,7 +14,11 @@ Wagtail defaults to serving :class:`~wagtail.core.models.Page`-derived models by
 
 Consider this example from the Wagtail demo site's ``models.py``, which serves an ``EventPage`` object as an iCal file if the ``format`` variable is set in the request:
 
+
+## Python emphasize
+
 .. code-block:: python
+   :emphasize-lines: 15-17
 
     class EventPage(Page):
         ...

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -30,14 +30,22 @@
     {%- if favicon %}
         <link rel="shortcut icon" href="{{ pathto('_static/' + favicon, 1) }}" />
     {%- endif %}
+
+    {#- Include our own stylesheets -#}
+    {%- if sphinx_version_info[0] < 4 %}
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/' + style, 1) }}" />
+    {%- endif %}
     <link rel="stylesheet" type="text/css" href="{{ pathto('_static/dist/fontawesome.css', 1) }}" />
+    {#- Include stylesheets from sphinx (e.g. user custom css #}
     {%- for css in css_files %}
+    {#- Block pygments css; we are manually including ours in theme.css instead #}
+    {%- if css not in ["_static/pygments.css"] %}
       {%- if css|attr("filename") %}
       {{ css_tag(css) }}
       {%- else %}
       <link rel="stylesheet" href="{{ pathto(css, 1)|e }}" type="text/css" />
       {%- endif %}
+    {%- endif %}
     {%- endfor %}
     {%- block linktags %}
         {%- if hasdoc('about') %}


### PR DESCRIPTION
Preview of code highlight: https://deploy-preview-154--sphinx-wagtail-theme.netlify.app/examples/rst-page.html

I cherry-picked @vsalvino commit from https://github.com/wagtail/sphinx_wagtail_theme/pull/125 and added an highlight example.

- We run our own pygments CSS
- Newest Sphinx adds pygments (falls back to some default)
- We don't want that file as those styles take precedence.

Alternative would be to start a specificity war in CSS.

The other PR explains it better. https://github.com/wagtail/sphinx_wagtail_theme/pull/125