### PR TITLE
Build instructions for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,7 @@ html_theme = 'sphinx_wagtail_theme'
 
 ### Getting started
 
--   Clone this repo locally
--   Set up a Python virtual environment (e.g. `venv`)
--   Show all available tasks via `make`
--   Run `make setup` to install the dependencies
--   Run `make frontend` to build the frontend assets
--   Run `make install-for-dev` to build the theme package and install it in editable mode
--   Run `make docs` to build the theme docs, which also serve as the example docs to develop the theme
--   Run `make serve` to serve the theme docs at http://localhost:8000
-
-See the documentation for more development instructions.
+-   [Instructions for Mac, Linux, and Windows](docs/development.rst)
 
 ### Release process
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -122,7 +122,7 @@ which will be ignored by git.
    ./.venv/Scripts/Activate.ps1
 
    # Install dependencies
-   pip install -r requirements.txt
+   pip install -r requirements-dev.txt
 
 Install the the NPM dependencies:
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -7,37 +7,57 @@ Development
 ===========
 
 
-For local development you need a system with Node v16.x, Python3, Git and
-make. It is strongly recommended to use a Python virtual environment (`venv`_).
+For local development you need a system with Node v16.x, Python3, and Git.
+It is strongly recommended to use a Python virtual environment (`venv`_).
 The build process derives the version from repository data, so it's necessary
 to clone the repository and not just download a single snapshot.
 
-Start with `make`::
+Mac or Linux
+============
+
+These steps require having ``make`` installed. If the first command below
+produces an error, you can follow the steps below in the Windows section.
+
+Start with ``make``
+
+.. code-block:: shell
 
    # show all available tasks
    make
 
-Install requirements and fulfill Python and Node demands (repeatable)::
+Install requirements and fulfill Python and Node demands (repeatable)
+
+.. code-block:: text
 
    make setup
 
-When doing frontend development compile your changes at any time::
+When doing frontend development compile your changes at any time
+
+.. code-block:: text
 
    make frontend
 
-Build and install the package::
+Build and install the package
+
+.. code-block:: text
 
    make install
 
-Don't forget to update the docs. Render the documentation::
+Don't forget to update the docs. Render the documentation
+
+.. code-block:: text
 
    make docs
 
-Serve build docs locally::
+Serve build docs locally
+
+.. code-block:: text
 
    make serve
 
-Check the Python code. The CI workflow requires `lint-minimal` to succeed::
+Check the Python code. The CI workflow requires ``lint-minimal`` to succeed
+
+.. code-block:: shell
 
    # for local use
    make lint
@@ -45,11 +65,15 @@ Check the Python code. The CI workflow requires `lint-minimal` to succeed::
    # used in the workflow
    make lint-minimal
 
-Run Python unit tests::
+Run Python unit tests
+
+.. code-block:: text
 
    make test
 
-Rebuild and install from Python wheel package::
+Rebuild and install from Python wheel package
+
+.. code-block:: shell
 
    make install
 
@@ -58,7 +82,9 @@ Rebuild and install from Python wheel package::
 
 
 To find out whether the created wheel package passes the `twine check` test and
-can be uploaded to PyPi run::
+can be uploaded to PyPi run
+
+.. code-block:: text
 
    make build test
 
@@ -66,7 +92,73 @@ can be uploaded to PyPi run::
 .. _venv: https://docs.python.org/3/library/venv.html
 
 
-Example pages
+Windows, or systems without ``make`` installed
+==============================================
+
+Windows does not have ``make`` therefore we must run the commands directly
+rather than using the shortcuts in the Makefile. Assume the commands below are
+all run in PowerShell. These instructions will also work on Mac or Linux without
+make installed as well.
+
+First, be sure to install Python 3, and Node 16.
+`nvm <https://github.com/coreybutler/nvm-windows>`_ is really useful for
+managing multiple versions of Node on Windows.
+
+Make a Python virtual environment. Let's make it in a folder called ``.venv``
+which will be ignored by git.
+
+.. code-block:: shell
+
+   # Create the venv
+   python -m venv ./.venv/
+
+   # Activate it (PowerShell)
+   ./.venv/Scripts/Activate.ps1
+
+   # Install dependencies
+   pip install -r requirements.txt
+
+Install the the NPM dependencies:
+
+.. code-block:: text
+
+   npm install
+
+Now, build the frontend (this compiles the CSS and JavaScript). Re-run this
+whenever you edit ``.scss`` or ``.js`` files.
+
+.. code-block:: text
+
+   npm run frontend
+
+To test out the sphinx theme, build the project's own documentation using the
+theme! The command below tells Sphinx to build the ``./docs/`` folder as HTML,
+and put the output HTML files in ``./docs/_build/``.
+
+.. code-block:: text
+
+   sphinx-build -M html ./docs/ ./docs/_build/
+
+If you see any red errors in the console, that would most likely be related to
+a syntax error in a ``.rst`` or ``.md`` file in the ``./docs/`` folder.
+
+To browse the docs you just built, fire up a simple web server using Python:
+
+.. code-block:: text
+
+   python -m http.server -d ./docs/_build/html/
+
+Now go to http://localhost:8000/ in your browser.
+
+If you make any changes to the Python code, you'll want to run the linters to
+check for errors:
+
+.. code-block:: text
+
+   flake8 .
+
+
+Example Pages
 =============
 
 When working on the theme it is often going to be helpful to know the impact of your changes.
@@ -78,4 +170,4 @@ When you are adding new elements or styles that are not part of the examples, pl
 Javascript package management
 =============================
 
-Use `npm` for package management.
+Use ``npm`` for package management.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,7 @@
--r ./requirements.txt
+# Install package into itself.
+-e .
+
+# Development tooling
 build
 docutils
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
+# Install package into itself.
+-e .
+
+# Install development tooling
 build
 flake8
 pip

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ universal = 1
 
 
 [flake8]
-exclude = .conda-*,.github,.pytest_cache,docs,node_modules,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg,*GENERATED*
+exclude = .*,docs,node_modules,CVS,__pycache__,*.egg,*GENERATED*
 max-line-length = 127
 
 


### PR DESCRIPTION
Finally writing down the build instructions for Windows (or any other system without `make` installed). I had to use these myself plus I have seen some similar questions come up in the Slack.

Couple other related changes:
* Install the local package as part of requirements.txt
* Ignore all hidden dot directories during flake8.