### PR TITLE
Deemphasised toc text

### DIFF
--- a/sass/_component_toc.scss
+++ b/sass/_component_toc.scss
@@ -13,6 +13,7 @@
 
     li:not(.toctree-l1) a {
         text-decoration: none;
+        color: $gray-600;
     }
 
     ul {


### PR DESCRIPTION
Fixes #20.
![Screenshot from 2022-04-10 00-19-00](https://user-images.githubusercontent.com/86092410/162587769-b92a84ae-cecc-4fc6-89a6-a810a68f5ac5.png)
