### PR TITLE
Deemphasized page toc color

### DIFF
--- a/sass/_component_toc.scss
+++ b/sass/_component_toc.scss
@@ -85,7 +85,6 @@
 
         &:hover,
         &:focus {
-            // color: $gray-500;
             color: $link-hover-color;
         }
 

--- a/sass/_component_toc.scss
+++ b/sass/_component_toc.scss
@@ -1,4 +1,3 @@
-
 .toc {
     a {
         position: relative;
@@ -50,6 +49,7 @@
             transform: translate(-50%, -50%);
         }
     }
+
     .current > a {
         color: theme-color('primary');
         > .toctree-expand {
@@ -60,6 +60,7 @@
             }
         }
     }
+
     > ul {
         padding-left: 0;
         .current {
@@ -68,6 +69,7 @@
             }
         }
     }
+
     > ul:not(:last-child) {
         padding-bottom: $spacer;
         border-bottom: 1px solid rgba(0, 0, 0, .15);
@@ -76,6 +78,20 @@
 
 .page-toc {
     font-size: ($font-size-base * 0.875);
+
+    a {
+        color: $gray-600;
+
+        &:hover,
+        &:focus {
+            // color: $gray-500;
+            color: $link-hover-color;
+        }
+
+        &:active {
+            color: $link-active-color;
+        }
+    }
 }
 
 .site-toc .toc {

--- a/sass/_component_toc.scss
+++ b/sass/_component_toc.scss
@@ -78,6 +78,7 @@
 
 .page-toc {
     font-size: ($font-size-base * 0.875);
+    color: $gray-700;
 
     a {
         color: $gray-600;


### PR DESCRIPTION
Sets text color for page toc to gray. 

**Before**
<img width="300" alt="image" src="https://user-images.githubusercontent.com/24797493/162587814-b76102dc-d0df-4794-8a20-64a6ddac93ab.png">

**After**
<img width="300" alt="image" src="https://user-images.githubusercontent.com/24797493/162587797-386f3050-4cf6-490b-962d-ff0bfca0e3dd.png">


This reduced the visual weight of the page toc and reduces it's importance, which makes sense because this is secondary content. 

Closes #20 