### PR TITLE
Fix link style in Safari

### DIFF
--- a/sass/_component_link.scss
+++ b/sass/_component_link.scss
@@ -1,6 +1,9 @@
 a {
     color: $link-color;
     text-decoration: 2px solid underline;
+    text-decoration-line: underline;
+    text-decoration-style: solid;
+    text-decoration-thickness: 2px;
     text-decoration-color: $link-border-color;
     text-underline-offset: 3px;
 
@@ -9,10 +12,12 @@ a {
         color: $link-hover-color;
         // This is necessary because of some weird `hover` mixin in bootstrap.
         text-decoration: 2px solid underline;
+        text-decoration-color: currentcolor;
     }
 
     &:active {
         color: $link-active-color;
         text-decoration: 2px solid underline;
+        text-decoration-color: currentcolor;
     }
 }


### PR DESCRIPTION
The shorthand does not quite work in Safari. Therefore, we need to define the different components individually.

Thanks to @PaarthAgarwal for the pointer! 

**Before**
<img width="300" alt="Screen Shot 2022-04-09 at 12 07 02 PM" src="https://user-images.githubusercontent.com/24797493/162588286-ff7d7987-6d26-4fa2-a32c-a0492f4a3a7a.png">


**After**
<img width="300" alt="Screen Shot 2022-04-09 at 12 06 34 PM" src="https://user-images.githubusercontent.com/24797493/162588291-c87de9cf-2853-42cc-a50c-77a3e56e51f7.png">


Close #155 