### PR TITLE
Set language to English for our own docs

### DIFF
--- a/USAGE.rst
+++ b/USAGE.rst
@@ -2,10 +2,12 @@
 Usage
 =====
 
-Select the "Sphinx Wagtail theme" in the `conf.py` file of a Sphinx project::
+Select the "Sphinx Wagtail theme" in the ``conf.py`` file of a Sphinx project:
+
+.. code-block:: python
 
    # include the theme in the list of extensions to be loaded
-   extensions = ['sphinx_wagtail_theme', …]
+   extensions = ['sphinx_wagtail_theme', ...]
 
    # select the theme
    html_theme = 'sphinx_wagtail_theme'
@@ -13,7 +15,9 @@ Select the "Sphinx Wagtail theme" in the `conf.py` file of a Sphinx project::
 
 For developers:
 
-The following snippet should always work if appended at the end of `conf.py`::
+The following snippet should always work if appended at the end of ``conf.py``:
+
+.. code-block:: python
 
    try:
       extensions

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ author = "Wagtail"
 version = sphinx_wagtail_theme.__version__
 # The full version, including alpha/beta/rc tags.
 release = sphinx_wagtail_theme.__version__
-language = None
+language = "en"
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', 'requirements.txt']
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False


### PR DESCRIPTION
Currently this results in a build error with the latest version of sphinx. Following our own guide: https://github.com/wagtail/sphinx_wagtail_theme/blob/main/CHANGELOG.md#510---2022-04-07

Also fixing a python syntax error in the usage code block (ellipses character vs 3 dots) which is throwing a build warning.