### PR TITLE
Fix - focusable button for toc expand toggle

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -63,32 +63,37 @@ function updateDarkMode(event, { isInitial = false } = {}) {
  */
 updateDarkMode(null, { isInitial: true });
 
-// Inject collapsible menu
-function toggleCurrent(event) {
-  event.preventDefault();
-  var link = event.currentTarget.parentElement;
-  var element = link.parentElement;
-  var siblings =
-    element.parentElement.parentElement.querySelectorAll("li.current");
-  for (var i = 0; i < siblings.length; i++) {
-    if (siblings[i] !== element) {
-      siblings[i].classList.remove("current");
-    }
-  }
-  element.classList.toggle("current");
-}
-
+/**
+ * Inject collapsible menu
+ */
 function makeMenuExpandable() {
-  var toc = document.querySelector(".toc");
-  var links = toc.getElementsByTagName("a");
-  for (var i = 0; i < links.length; i++) {
-    if (links[i].nextSibling) {
-      var expand = document.createElement("span");
-      expand.classList.add("toctree-expand");
-      expand.addEventListener("click", toggleCurrent, true);
-      links[i].prepend(expand);
-    }
+  function toggleCurrent(event) {
+    const expandButton = event.currentTarget;
+    const element = expandButton.parentElement;
+    const siblings =
+      element.parentElement.parentElement.querySelectorAll("li.current");
+
+    siblings.forEach((sibling) => {
+      if (sibling !== element) {
+        sibling.classList.remove("current");
+      }
+    });
+
+    element.classList.toggle("current");
   }
+
+  const toc = document.querySelector(".toc");
+  const links = Array.from(toc.getElementsByTagName("a"));
+  const template = document.querySelector("[data-toggle-item-template]");
+  const templateChild = template.content.firstElementChild;
+
+  links.forEach((link) => {
+    if (link.nextSibling) {
+      const expandButton = templateChild.cloneNode(true);
+      expandButton.addEventListener("click", toggleCurrent, true);
+      link.before(expandButton);
+    }
+  });
 }
 
 makeMenuExpandable();

--- a/sass/_component_header.scss
+++ b/sass/_component_header.scss
@@ -31,8 +31,4 @@ header {
   .navbar-dark .navbar-nav .nav-link {
     color: $link-alternate-color;
   }
-
-  .navbar-toggler-text {
-    @include sr-only;
-  }
 }

--- a/sass/_component_toc.scss
+++ b/sass/_component_toc.scss
@@ -1,6 +1,5 @@
 .toc {
   a {
-    position: relative;
     display: inline-block;
     line-height: 1.25;
     padding: ($spacer / 4) 0;
@@ -8,6 +7,11 @@
 
   li {
     margin: $size-1 0;
+
+    &[class^="toctree-"] {
+      // ensure the toctree-expand button can be positioned
+      position: relative;
+    }
   }
 
   li:not(.toctree-l1) a {
@@ -23,7 +27,7 @@
     position: absolute;
     display: block;
     top: (($spacer / 4) + ($font-size-base * 1.25 / 2));
-    left: -$size-6;
+    left: -$size-5;
     transform: translate(0, -50%);
     height: 1em;
     width: 1em;

--- a/sphinx_wagtail_theme/globaltoc.html
+++ b/sphinx_wagtail_theme/globaltoc.html
@@ -1,5 +1,10 @@
 <div class="site-toc">
-    <nav class="toc mt-3" aria-label="Main menu">
+    <nav class="toc mt-3" aria-label="{{ _('Main menu') }}">
         {{ toctree(includehidden=False, collapse=False, maxdepth=8, titles_only=True) }}
     </nav>
+    <template data-toggle-item-template>
+        <button class="btn btn-sm btn-link toctree-expand" type="button">
+            <span class="sr-only">{{ _('Toggle menu contents') }}</span>
+        </button>
+    </template>
 </div>

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -105,7 +105,7 @@
                 {% endif %}
                 <button class="navbar-toggler btn btn-primary d-lg-none" type="button" data-toggle="collapse" data-target="#collapseSidebar" aria-expanded="false" aria-controls="collapseExample">
                     <span class="navbar-toggler-icon"></span>
-                    <span class="navbar-toggler-text">Menu</span>
+                    <span class="sr-only">Menu</span>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
- resolves https://github.com/wagtail/sphinx_wagtail_theme/issues/104
- adds a focusable (button) for the expand TOC toggle
- include HTML template element to set up classes & translated screen reader description much easier
- revise DOM position so it is the same visually as the tab order
- move in slightly so focus outline is visible
- also fixes an issue where the screen reader main menu label would not be translatable

**Caveats**

* Positioning may be odd for screen readers as it is 'before' the content it is expanding - but this would be a more complex fix that requires ids to be added to each TOC item. Recommend we add aria-controls & aria-expanded attributes as a new improvement issue.
* These changes will not support IE11 - but other recent code changes will break in IE11 anyway


<img width="406" alt="Screen Shot 2022-08-19 at 5 10 03 pm" src="https://user-images.githubusercontent.com/1396140/185563763-e7c08522-8037-482d-9071-23dacff87c93.png">

