### PR TITLE
Change bootstrap colors to match wagtail style guide

### DIFF
--- a/sass/_component_admotion.scss
+++ b/sass/_component_admotion.scss
@@ -7,7 +7,7 @@
 // - Horizontal Buttons
 // ----
 .admonition {
-  background-color: theme-color-level("info", -11);
+  background-color: $gray-100;
   margin: $spacer 0;
   padding: $spacer;
   box-shadow: $box-shadow-sm;
@@ -20,22 +20,18 @@
 
   &.hint,
   &.note {
-    background-color: theme-color-level("info", -11);
-
     .admonition-title {
-      color: color-yiq(theme-color("info"));
-      background-color: theme-color("info");
+      color: color-yiq($info);
+      background-color: $info;
     }
   }
 
   &.caution,
   &.warning,
   &.attention {
-    background-color: theme-color-level("warning", -11);
-
     .admonition-title {
-      color: color-yiq(theme-color("warning"));
-      background-color: theme-color("warning");
+      color: color-yiq($warning);
+      background-color: $warning;
 
       &:before {
         content: fa-content($fa-var-exclamation-triangle);
@@ -45,11 +41,9 @@
 
   &.danger,
   &.error {
-    background-color: theme-color-level("danger", -11);
-
     .admonition-title {
-      color: color-yiq(theme-color("danger"));
-      background-color: theme-color("danger");
+      color: color-yiq($danger);
+      background-color: $danger;
 
       &:before {
         content: fa-content($fa-var-exclamation-triangle);
@@ -60,11 +54,9 @@
   &.important,
   &.seealso,
   &.tip {
-    background-color: theme-color-level("success", -11);
-
     .admonition-title {
-      color: color-yiq(theme-color("success"));
-      background-color: theme-color("success");
+      color: color-yiq($success);
+      background-color: $success;
     }
   }
 }
@@ -74,8 +66,8 @@
   padding: ($spacer / 2) $spacer;
   margin: -$spacer;
   margin-bottom: $spacer;
-  color: color-yiq(theme-color("info"));
-  background-color: theme-color("info");
+  color: color-yiq($info);
+  background-color: $info;
   font-weight: $font-weight-bold;
 
   &:before {
@@ -87,28 +79,6 @@
 // For dark mode, use darker background colors.
 body.theme-dark {
   .admonition {
-    background-color: $darkmode-info;
-
-    &.hint,
-    &.note {
-      background-color: $darkmode-info;
-    }
-
-    &.caution,
-    &.warning,
-    &.attention {
-      background-color: $darkmode-warning;
-    }
-
-    &.danger,
-    &.error {
-      background-color: $darkmode-danger;
-    }
-
-    &.important,
-    &.seealso,
-    &.tip {
-      background-color: $darkmode-success;
-    }
+    background-color: $darkmode-bg-lighter;
   }
 }

--- a/sass/_component_pygments.scss
+++ b/sass/_component_pygments.scss
@@ -5,7 +5,7 @@ pre {
   border-radius: 5px;
   font-size: 14px;
   color: $base16-base07;
-  background-color: $indigo;
+  background-color: $primary;
 
   .hll {
     background-color: $base16-base02;

--- a/sass/_component_version.scss
+++ b/sass/_component_version.scss
@@ -25,11 +25,11 @@
 }
 
 .versionadded {
-  background-color: theme-color-level("success", -11);
+  background-color: $gray-100;
 
   .versionmodified {
-    color: color-yiq(theme-color("success"));
-    background-color: theme-color("success");
+    color: color-yiq($success);
+    background-color: $success;
 
     &:before {
       content: fa-content($fa-var-info-circle);
@@ -38,11 +38,11 @@
 }
 
 .versionchanged {
-  background-color: theme-color-level("warning", -11);
+  background-color: $gray-100;
 
   .versionmodified {
-    color: color-yiq(theme-color("warning"));
-    background-color: theme-color("warning");
+    color: color-yiq($warning);
+    background-color: $warning;
 
     &:before {
       content: fa-content($fa-var-exclamation-triangle);
@@ -51,11 +51,11 @@
 }
 
 .deprecated {
-  background-color: theme-color-level("danger", -11);
+  background-color: $gray-100;
 
   .versionmodified {
-    color: color-yiq(theme-color("danger"));
-    background-color: theme-color("danger");
+    color: color-yiq($danger);
+    background-color: $danger;
     border-radius: unset;
     box-shadow: unset;
 
@@ -68,20 +68,20 @@
 // For dark mode, use darker background colors.
 body.theme-dark {
   .versionchanged {
-    background-color: $darkmode-warning;
+    background-color: $darkmode-bg-lighter;
   }
 
   .deprecated {
-    background-color: $darkmode-danger;
+    background-color: $darkmode-bg-lighter;
 
     // Need to override this to be the same as above, due to how the class names
     // are generated in the docs.
     .versionmodified {
-      background-color: theme-color("danger");
+      background-color: $danger;
     }
   }
 
   .versionadded {
-    background-color: $darkmode-success;
+    background-color: $darkmode-bg-lighter;
   }
 }

--- a/sass/_component_versionpicker_fix.scss
+++ b/sass/_component_versionpicker_fix.scss
@@ -30,7 +30,7 @@ These overrides are necessary to make the version picker work with the Sphinx Wa
   text-align: end;
   font-size: 90%;
   cursor: pointer;
-  background-color: $indigo;
+  background-color: $primary;
   color: $white;
   *zoom: 1;
 

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -1,39 +1,42 @@
 @use "sass:color";
 
 // --------------------------------------------------
-// Colors
+// Colors.
+// Follow style guide: https://www.figma.com/community/file/1098619062654073532
 // --------------------------------------------------
 
-$white: #fff;
-$gray-100: #f2f2f2;
-$gray-200: #e9e9e9;
-$gray-300: #dedede;
-$gray-400: #cecece;
-$gray-500: #ababab;
-$gray-600: #6c6c6c;
-$gray-700: #494949;
-$gray-800: #313131;
-$gray-900: #212121;
-$black: #000;
+$white:    #fff;
+$gray-100: #f6f6f8;
+$gray-200: #e0e0e0;
+$gray-300: #c8c8c8;
+$gray-400: #c8c8c8;
+$gray-500: #929292;
+$gray-600: #929292;
+$gray-700: #5c5c5c;
+$gray-800: #5c5c5c;
+$gray-900: #262626;
+$black:    #000;
 
-$teal: #007d7e;
-$indigo: #2e1f5e;
-$bright-green: #3beccd;
-$bright-green-700: color.adjust($bright-green, $lightness: -15%);
-$bright-green-900: color.adjust($bright-green, $lightness: -30%);
+$teal-100: #f2fcfc;
+$teal-200: #80d7d8;
+$teal-300: #00b0b1;
+$teal-400: #007d7e;
+$teal-500: #005b5e;
+$teal-600: #004345;
 
-$primary: $indigo;
-$success: #a456c9;
-$info: $teal;
-$warning: #2f128d;
-$danger: #a72925;
-$search: #ffe69c;
+$primary:  #2e1f5e;
+$success:  #1b8666;
+$info:     #1f7e9a;
+$warning:  #faa500;
+$danger:   #cd4444;
+
+$search:   $teal-200;
 
 $link-color: $primary;
-$link-border-color: $bright-green;
-$link-hover-color: $bright-green-700;
-$link-active-color: $bright-green-900;
-$link-border-active-color: $bright-green-900;
+$link-border-color: $teal-300;
+$link-hover-color: $teal-300;
+$link-active-color: $teal-300;
+$link-border-active-color: $teal-300;
 
 $link-alternate-color: #fff;
 $link-alternate-hover-color: color.adjust(
@@ -45,16 +48,12 @@ $table-bg: $white;
 
 $yiq-contrasted-threshold: 160;
 
-$focus-outline: #1f7e9a;
+$focus-outline: $teal-300;
 
 $darkmode-color: rgba(255, 255, 255, 0.8);
 $darkmode-color-darker: rgba(255, 255, 255, 0.6);
 $darkmode-bg: color.adjust($primary, $lightness: -15%);
-$darkmode-bg-lighter: color.adjust($primary, $lightness: -10%);
-$darkmode-danger: color.adjust($danger, $lightness: -25%);
-$darkmode-info: color.adjust($info, $lightness: -15%);
-$darkmode-success: color.adjust($success, $lightness: -30%);
-$darkmode-warning: color.adjust($warning, $lightness: -18%);
+$darkmode-bg-lighter: color.adjust($primary, $lightness: -10%, $saturation: -10%);
 
 // --------------------------------------------------
 // Code Colors


### PR DESCRIPTION
Did this more as an experiment... personally I find that most of the colors look worse, or at least less exciting, when following the style guide (e.g. teal is darker than the bright green, admonition colors are more generic). Obviously the design of the docs is different than the design of the Wagtail admin, so the style guide is not necessarily a good guide in this case.

Posting this here for people to check out and play with if interested. Personally I do not think it is worth merging in.

Changes:
* Use color codes defined in the draft style guide: https://www.figma.com/community/file/1098619062654073532
* Switch admonition bodies to use light gray instead of light version of the color. This is because the various colors are not always easily readable when the admonition contains things like code, links, etc. which have their own colors. This problem is exacerbated in darkmode when trying to find a suitable dark version of yellow for example.