### PR TITLE
Fix link styles in Safari (again)

### DIFF
--- a/sass/_component_link.scss
+++ b/sass/_component_link.scss
@@ -1,19 +1,27 @@
+// reminder - Safari does NOT support shorthand for text-decoration
 a {
   color: $link-color;
-  text-decoration: $link-border-color 2px solid underline;
   text-underline-offset: 3px;
+  text-decoration-color: $link-border-color;
+
+  &,
+  &:focus,
+  &:hover,
+  &:active {
+    // additional reset necessary because of some weird `hover` mixin in bootstrap.
+    text-decoration: underline;
+    text-decoration-style: solid;
+    text-decoration-thickness: 2px;
+  }
 
   &:focus,
   &:hover {
     color: $link-hover-color;
-    // This is necessary because of some weird `hover` mixin in bootstrap.
-    text-decoration: 2px solid underline;
     text-decoration-color: currentcolor;
   }
 
   &:active {
     color: $link-active-color;
-    text-decoration: 2px solid underline;
     text-decoration-color: currentcolor;
   }
 }

--- a/sass/_darkmode.scss
+++ b/sass/_darkmode.scss
@@ -20,14 +20,12 @@ body.theme-dark {
 
   .btn-link,
   a {
+    // reminder - Safari does NOT support shorthand for text-decoration
     color: $darkmode-color;
 
     &:focus,
     &:hover {
       color: $link-hover-color;
-      // This is necessary because of some weird `hover` mixin in bootstrap.
-      text-decoration: 2px solid underline;
-      text-decoration-color: currentcolor;
     }
   }
 


### PR DESCRIPTION
- fixes #206
- fixes #155 again
- Not sure why we keep running into these issues but hopefully fixed for good now - basically just bypassing the `shorthand` variant completely as it does not work as expected 


https://caniuse.com/mdn-css_properties_text-decoration_shorthand - requires prefix if we want to use it but simpler to keep this out of the scss.

<img width="1494" alt="Screen Shot 2022-09-11 at 2 23 00 pm" src="https://user-images.githubusercontent.com/1396140/189512304-550e9439-f727-40b5-9396-c88692499c3e.png">



### Screenshots - Before

> Left is Firefox, Right is Safari

<img width="1617" alt="Screen Shot 2022-09-11 at 1 49 16 pm" src="https://user-images.githubusercontent.com/1396140/189512332-072c5864-85fb-4405-a2a2-73dbf2831642.png">

<img width="1574" alt="Screen Shot 2022-09-11 at 1 49 08 pm" src="https://user-images.githubusercontent.com/1396140/189512335-e24aa95c-aaf0-43b2-b761-f759a6caffc0.png">


## Screenshots - After

> Left is Firefox, Right is Safari

<img width="1612" alt="Screen Shot 2022-09-11 at 2 18 18 pm" src="https://user-images.githubusercontent.com/1396140/189512349-4125a087-c556-4a31-ba5c-9114ee56c36f.png">


<img width="1721" alt="Screen Shot 2022-09-11 at 2 18 34 pm" src="https://user-images.githubusercontent.com/1396140/189512346-960e0802-9db0-4631-a334-2ccebe6963dc.png">