### PR TITLE
Fix - ensure darkmode body class toggle does not wipe other classes

### DIFF
--- a/js/theme.js
+++ b/js/theme.js
@@ -48,7 +48,7 @@ function updateDarkMode(event, { isInitial = false } = {}) {
   }
 
   // set applied mode to the DOM
-  document.body.className = applyMode === DARK ? "theme-dark" : "";
+  document.body.classList.toggle("theme-dark", applyMode === DARK);
 
   // only store value if already stored OR was triggered by an actual click
   if (savedThemeMode || event) {


### PR DESCRIPTION
- fixes #203

## How to test

* Build the code locally
* Manually add some other class to the body with the DOM inspector
* Toggle the darkmode on / off & check that the class added is still there
