### PR TITLE
Add skip to main content link (keyboard control only)

### DIFF
--- a/sass/_layout.scss
+++ b/sass/_layout.scss
@@ -15,3 +15,14 @@ li > p {
   outline-offset: 1px;
   box-shadow: none;
 }
+
+.skip-to-content-link {
+  left: 50%;
+  position: absolute;
+  transform: translateY(-100%);
+  transition: transform 0.3s;
+
+  &:focus {
+    transform: translateY(0%);
+  }
+}

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -76,6 +76,7 @@
 <body>
     <script type="text/javascript" src="{{ pathto('_static/dist/blocking.js', 1) }}"></script>
     <header class="container-fluid bg-primary">
+        <a class="btn btn-sm btn-light skip-to-content-link" href="#main">{{ _('Skip to content') }}</a>
         <div class="container-fluid">
             <div class="navbar navbar-expand-lg navbar-dark font-weight-bold">
                 {%- if theme_logo and theme_logo != 'None' %}
@@ -106,7 +107,7 @@
                 {% endif %}
                 <button class="navbar-toggler btn btn-primary d-lg-none" type="button" data-toggle="collapse" data-target="#collapseSidebar" aria-expanded="false" aria-controls="collapseExample">
                     <span class="navbar-toggler-icon"></span>
-                    <span class="sr-only">Menu</span>
+                    <span class="sr-only">{{ _('menu') }}</span>
                 </button>
             </div>
         </div>
@@ -148,7 +149,7 @@
                 </div>
                 <div class="row">
                     <div class="col-12 col-lg-9 order-last order-lg-first rst-content">
-                        <main role="main">
+                        <main role="main" id="main">
                             {%- block body %}
                             {% endblock -%}
                         </main>


### PR DESCRIPTION
- Resolves #202
- Also ensure the main toggle text (screen reader only) can be translated)
- Note: On really small devices is overlaps the title a bit but I think this would be acceptable for the use cases of this kind of link.
- Nothing too fancy, just an internal ID lnk with focus state showing it visibly.

## Screenshots


<img width="1377" alt="Screen Shot 2022-09-11 at 2 30 38 pm" src="https://user-images.githubusercontent.com/1396140/189512559-5f4d53a4-73ec-4894-b2f2-1e5e0be105c7.png">
<img width="897" alt="Screen Shot 2022-09-11 at 2 30 19 pm" src="https://user-images.githubusercontent.com/1396140/189512564-76f30479-2657-478e-b21e-b50ad65fa2ad.png">
