### PR TITLE
FIX - fixed text overflow in TOC sections (#204)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
--   ...
+-   Update page contents (right sidebar) to ensure horizontal scrollbars do not appear (Kartik Kankurte)
 
 ### Removed
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,6 +8,7 @@
 -   Paarth Agarwal
 -   Vince Salvino
 -   LB (Ben) Johnston
+-   Kartik Kankurte
 
 ## Sphinx Typo3 theme
 

--- a/sass/_component_toc.scss
+++ b/sass/_component_toc.scss
@@ -92,6 +92,8 @@
   color: $gray-700;
   max-height: 100vh;
   overflow-y: auto;
+  overflow-x: hidden;
+  word-break: break-all;
 
   a {
     color: $gray-600;


### PR DESCRIPTION
#204 removed horizontal scrollbar in the TOC section and made it to wrap and go to next line