### PR TITLE
Fix issue where theme would flash incorrectly on load

### DIFF
--- a/js/blocking.js
+++ b/js/blocking.js
@@ -1,0 +1,78 @@
+/**
+ * IMPORTANT: This script will block the DOM from loading, only add critical path JS here.
+ */
+
+/**
+ * Set and store dark/light (theme) mode.
+ *
+ * Mode will be set to be one of "light" or "dark", by default the resolved
+ * theme mode will be flipped (e.g. light to dark).
+ *
+ * @param {Event} event - is for usage with event listeners, and indicates the user has manually clicked a button
+ * @param {object?} options - additional options param when called explicitly
+ * @param {boolean?} options.isInitial - if true the current value will be resolved & set NOT toggled
+ */
+function updateThemeMode(event, { isInitial = false } = {}) {
+  const DARK = "dark";
+  const LIGHT = "light";
+  const STORAGE_KEY = "wagtail-theme";
+
+  let currentMode;
+  let applyMode;
+  let savedThemeMode;
+
+  // safely request local storage - if cookies/storage is disabled it should not error
+  try {
+    savedThemeMode = localStorage.getItem(STORAGE_KEY);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.warn("Unable to read theme from localStorage", error);
+  }
+
+  // find the current mode from existing storage or browser preference
+  if (savedThemeMode) {
+    // note - do not assume correct format of local storage
+    currentMode = savedThemeMode === LIGHT ? LIGHT : DARK;
+  } else {
+    // fall back on browser media for first toggle
+    const prefersDarkMode = window.matchMedia(
+      "(prefers-color-scheme:dark)"
+    ).matches;
+
+    currentMode = prefersDarkMode ? DARK : LIGHT;
+  }
+
+  // if running initially - do not 'flip' - instead apply current mode
+  if (isInitial) {
+    applyMode = currentMode === DARK ? DARK : LIGHT;
+  } else {
+    applyMode = currentMode === DARK ? LIGHT : DARK;
+  }
+
+  // set applied mode to the DOM
+  document.body.classList.toggle("theme-dark", applyMode === DARK);
+
+  // only store value if already stored OR was triggered by an actual click
+  if (savedThemeMode || event) {
+    try {
+      localStorage.setItem(STORAGE_KEY, applyMode);
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.warn("Unable to store theme in localStorage", error);
+    }
+  }
+}
+
+/**
+ * Apply user's saved light/dark preference, or fall back to browser setting.
+ * Load light/dark preference before DOMContentLoaded so the user does not see a
+ * flash during theme initialisation.
+ */
+updateThemeMode(null, { isInitial: true });
+
+/**
+ * Set up event listener for other manual toggling.
+ */
+document.addEventListener("theme:toggle-theme-mode", updateThemeMode, {
+  passive: true,
+});

--- a/js/theme.js
+++ b/js/theme.js
@@ -9,61 +9,6 @@ if (typeof window.T3Docs === "undefined") {
 }
 
 /**
- * Set and store dark/light mode.
- *
- * Mode will be set to be one of "light" or "dark", by default the resolved
- * theme mode will be flipped (e.g. light to dark).
- *
- * @param {Event} event - is for usage with event listeners, and indicates the user has manually clicked a button
- * @param {object?} options
- * @param {boolean?} options.isInitial - if true the current value will be resolved & set NOT toggled
- */
-function updateDarkMode(event, { isInitial = false } = {}) {
-  const DARK = "dark";
-  const LIGHT = "light";
-  const STORAGE_KEY = "wagtail-theme";
-
-  let currentMode;
-  let applyMode;
-  const savedThemeMode = localStorage.getItem(STORAGE_KEY);
-
-  // find the current mode from existing storage or browser preference
-  if (savedThemeMode) {
-    // note - do not assume correct format of local storage
-    currentMode = savedThemeMode === LIGHT ? LIGHT : DARK;
-  } else {
-    // fall back on browser media for first toggle
-    const prefersDarkMode = window.matchMedia(
-      "(prefers-color-scheme:dark)"
-    ).matches;
-
-    currentMode = prefersDarkMode ? DARK : LIGHT;
-  }
-
-  // if running initially - do not 'flip' - instead apply current mode
-  if (isInitial) {
-    applyMode = currentMode === DARK ? DARK : LIGHT;
-  } else {
-    applyMode = currentMode === DARK ? LIGHT : DARK;
-  }
-
-  // set applied mode to the DOM
-  document.body.classList.toggle("theme-dark", applyMode === DARK);
-
-  // only store value if already stored OR was triggered by an actual click
-  if (savedThemeMode || event) {
-    localStorage.setItem(STORAGE_KEY, applyMode);
-  }
-}
-
-/**
- * Apply user's saved light/dark preference, or fall back to browser setting.
- * Load light/dark preference before DOMContentLoaded so the user does not see a
- * flash during theme initialisation.
- */
-updateDarkMode(null, { isInitial: true });
-
-/**
  * Inject collapsible menu
  */
 function makeMenuExpandable() {
@@ -115,7 +60,9 @@ document.addEventListener("DOMContentLoaded", () => {
   // Wire up light/dark mode button.
   document
     .getElementById("wagtail-theme")
-    .addEventListener("click", updateDarkMode);
+    .addEventListener("click", (event) => {
+      document.dispatchEvent(new CustomEvent("theme:toggle-theme-mode", event));
+    });
 
   // Search.
   var searchform = document.getElementById("search-form");

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -74,6 +74,7 @@
     {%- block extrahead %}{% endblock -%}
 </head>
 <body>
+    <script type="text/javascript" src="{{ pathto('_static/dist/blocking.js', 1) }}"></script>
     <header class="container-fluid bg-primary">
         <div class="container-fluid">
             <div class="navbar navbar-expand-lg navbar-dark font-weight-bold">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@ const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 module.exports = {
   devtool: "source-map",
   entry: {
+    blocking: path.resolve(__dirname, "js/blocking.js"),
     theme: path.resolve(__dirname, "js/theme.js"),
     fontawesome: path.resolve(__dirname, "sass/fontawesome.scss"),
   },


### PR DESCRIPTION
- add `blocking.js` to house the blocking JS
- add blocking script to the `body` tag to ensure it runs before the DOM is fully parsed
- revise API to be event listener based for manual toggle instead of a locally scoped function
- add better safety for when local storage is not available through try/catch
- fixes #213