### PR TITLE
Ensure version picker correctly shows above right sidebar

### DIFF
--- a/sass/_component_versionpicker_fix.scss
+++ b/sass/_component_versionpicker_fix.scss
@@ -11,8 +11,7 @@ These overrides are necessary to make the version picker work with the Sphinx Wa
   max-height: calc(100vh - 50px);
   overflow-y: auto;
   background: #1f1d1d;
-  // font-family: "Lato", "proxima-nova", "Helvetica Neue", Arial, sans-serif;
-  z-index: 400;
+  z-index: 1050;
 
   &.shift-up .rst-other-versions {
     display: block;


### PR DESCRIPTION

## Before

<img width="1430" alt="Screen Shot 2022-10-12 at 7 57 25 am" src="https://user-images.githubusercontent.com/1396140/195205909-779060eb-9fa5-40cd-996d-43f2bd1877f2.png">

<img width="1188" alt="Screen Shot 2022-10-12 at 7 57 15 am" src="https://user-images.githubusercontent.com/1396140/195205927-77475a87-fc4d-454f-965e-e2f66ec832f1.png">

## After

<img width="1428" alt="Screen Shot 2022-10-12 at 7 58 17 am" src="https://user-images.githubusercontent.com/1396140/195206011-95b87ed7-a742-42de-932b-000bdadb26bd.png">

<img width="1200" alt="Screen Shot 2022-10-12 at 7 58 24 am" src="https://user-images.githubusercontent.com/1396140/195205990-b21aa7a0-90ff-4882-85ab-9c4d0b01c3c9.png">