### PR TITLE
Fix "make test-import"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ test-tox: ##- Run tests on every Python version with tox
 .PHONY: test-import
 test-import: ## Verify the extension is install and can be imported
 	python3 -c "import sphinx_wagtail_theme as m; print(m.__version__)"
-	python3 -c "import sphinx_wagtail_theme as m, pprint; pprint.pprint(m.version_info)"
+	python3 -c "import sphinx_wagtail_theme as m, pprint; pprint.pprint(m.__version_full__)"
 
 .PHONY: test-visual-regression
 test-visual-regression: ## Run visual regression tests


### PR DESCRIPTION
The "make test-import" command currently tries to validate a local installation by importing `sphinx_wagtail_theme.version_info`, but this was removed in 5176ee511189102a13618a849f45bf64df63fe80, and replaced by `__version_full__`. This commit fixes that command to use the updated attribute.