### PR TITLE
Fix issue where link underlines were not showing the correct color

### DIFF
--- a/sass/_component_link.scss
+++ b/sass/_component_link.scss
@@ -1,18 +1,14 @@
-// reminder - Safari does NOT support shorthand for text-decoration
 a {
+  // additional reset necessary because of some weird `hover` mixin in bootstrap.
+  text-decoration: underline;
+
+  // base link styles
+  // reminder - Safari does NOT support shorthand for text-decoration
   color: $link-color;
   text-underline-offset: 3px;
+  text-decoration-thickness: 2px;
+  text-decoration-style: solid;
   text-decoration-color: $link-border-color;
-
-  &,
-  &:focus,
-  &:hover,
-  &:active {
-    // additional reset necessary because of some weird `hover` mixin in bootstrap.
-    text-decoration: underline;
-    text-decoration-style: solid;
-    text-decoration-thickness: 2px;
-  }
 
   &:focus,
   &:hover {


### PR DESCRIPTION
- Fixes https://github.com/wagtail/sphinx_wagtail_theme/issues/222


## Screenshots

### Firefox

<img width="1010" alt="Screen Shot 2022-10-15 at 9 57 52 am" src="https://user-images.githubusercontent.com/1396140/195959136-b958ae68-7007-47a3-a07f-e6f6ac1f5963.png">

<img width="1040" alt="Screen Shot 2022-10-15 at 9 58 01 am" src="https://user-images.githubusercontent.com/1396140/195959140-978d0070-c48f-4299-8c8c-712599fcfe9d.png">

### Safari 

<img width="1698" alt="Screen Shot 2022-10-15 at 9 58 23 am" src="https://user-images.githubusercontent.com/1396140/195959159-fe9cba22-eda0-4829-9172-a976cf9f28a3.png">

<img width="1704" alt="Screen Shot 2022-10-15 at 9 58 37 am" src="https://user-images.githubusercontent.com/1396140/195959168-6ef96639-9ece-4f16-9900-5feb8cdde498.png">


### Chrome


<img width="1428" alt="Screen Shot 2022-10-15 at 9 58 57 am" src="https://user-images.githubusercontent.com/1396140/195959187-46129290-2faa-417f-9a82-e87349282c76.png">

<img width="1424" alt="Screen Shot 2022-10-15 at 9 59 09 am" src="https://user-images.githubusercontent.com/1396140/195959196-8f0e6c2f-2567-4e49-a526-a5869e26deb9.png">

