### PR TITLE
Styling for reference generated using Autodoc

### DIFF
--- a/sass/_component_autodoc.scss
+++ b/sass/_component_autodoc.scss
@@ -1,0 +1,5 @@
+dl.class {
+  .sig-object + dd {
+    margin: 0 0 0.5rem 1.5rem;
+  }
+}

--- a/sass/theme.scss
+++ b/sass/theme.scss
@@ -26,6 +26,7 @@
 @import "component_toc";
 @import "component_version";
 @import "component_versionpicker_fix";
+@import "component_autodoc";
 
 // misc
 @import "layout";


### PR DESCRIPTION
This pull request addresses an indentation problem ( issue #228) when using `sphinx.ext.autodoc` to generate documentation automatically from the source code. 


