### PR TITLE
Updated layout to adjust width on xl screens

### DIFF
--- a/sass/_component_toc.scss
+++ b/sass/_component_toc.scss
@@ -91,8 +91,9 @@
   padding-top: 2.4rem;
   color: $gray-700;
   max-height: 100vh;
+  max-width: 100%;
   overflow-y: auto;
-  overflow-x: hidden;
+  overflow-x: hidden !important;
   word-break: break-all;
 
   a {

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -114,7 +114,7 @@
     </header>
     <div class="container-fluid">
         <div class="row">
-            <aside class="col-12 col-lg-3 col-xl-2 sidebar-container">
+            <aside class="col-12 col-lg-3 sidebar-container">
                 <div id="collapseSidebar" class="collapse sticky-top d-lg-block pt-5 pr-lg-4">
                     {%- for sidebartemplate in sidebars %}
                     {%- include sidebartemplate %}
@@ -124,7 +124,7 @@
                     </div>
                 </div>
             </aside>
-            <div class="col-12 col-lg-9 col-xl-10 pt-5">
+            <div class="col-12 col-lg-9 pt-5">
                 <header class="row align-items-baseline">
                     <div class="col">
                         {% include "breadcrumbs.html" %}

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -114,7 +114,7 @@
     </header>
     <div class="container-fluid">
         <div class="row">
-            <aside class="col-12 col-lg-3 sidebar-container">
+            <aside class="col-12 col-lg-3 col-xl-2 sidebar-container">
                 <div id="collapseSidebar" class="collapse sticky-top d-lg-block pt-5 pr-lg-4">
                     {%- for sidebartemplate in sidebars %}
                     {%- include sidebartemplate %}
@@ -124,7 +124,7 @@
                     </div>
                 </div>
             </aside>
-            <div class="col-12 col-lg-9 pt-5">
+            <div class="col-12 col-lg-9 col-xl-10 pt-5">
                 <header class="row align-items-baseline">
                     <div class="col">
                         {% include "breadcrumbs.html" %}


### PR DESCRIPTION
Updated layout to adjust width on xl screens
Fixes https://github.com/wagtail/sphinx_wagtail_theme/issues/223
Adjusted the width for larger screens using bootstrap classes "col-xl-2" "col-xl-2" to remove the extra width