### PR TITLE
Remove DocSearch meta tags

### DIFF
--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -20,10 +20,6 @@
         {{ metatags }}
     {%- endif %}
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="docsearch:name" content="{{ project|striptags|e }}" />
-    <meta name="docsearch:package_type" content="{{ package_type|striptags|e }}" />
-    <meta name="docsearch:release" content="{{ release|striptags|e }}" />
-    <meta name="docsearch:version" content="{{ version|striptags|e }}" />
     {% block htmltitle %}
         <title>{{ title|striptags|e }}{{ titlesuffix }}</title>
     {% endblock %}


### PR DESCRIPTION
Cleaning up so our Algolia DocSearch integration for Wagtail itself is easier to manage in the future: we can have the meta tags defined on `wagtail/wagtail`, like all other aspects of the integration. And:

- `docsearch:name` is useless (it’ll be the same for all builds of the docs)
- `docsearch:package_type` is empty
- `docsearch:release` is less apporpriate than `docsearch:version`.

Even `docsearch:version` isn’t well set up currently. Using the `version` variable means both the `stable` and `vX.Y` variants of the documentation would be indexed with the same version. We need to switch to the Read the Docs `current_version` instead (see https://github.com/wagtail/wagtail/pull/10207).