### PR TITLE
Fix search highlight illegible in code blocks

### DIFF
--- a/sass/_component_pygments.scss
+++ b/sass/_component_pygments.scss
@@ -6,7 +6,7 @@ pre {
   font-size: 14px;
   color: $base16-base07;
   background-color: $indigo;
-
+  
   .hll {
     background-color: $base16-base02;
   }
@@ -284,4 +284,7 @@ pre {
       color: $base16-base07;
     }
   }
+}
+.highlight .hll {
+  background-color: color.adjust($base16-base03);
 }

--- a/sass/_component_pygments.scss
+++ b/sass/_component_pygments.scss
@@ -286,5 +286,5 @@ pre {
   }
 }
 .highlight .hll {
-  background-color: color.adjust($base16-base03);
+  background-color: color.adjust($base16-base03, $alpha: -0.4);
 }


### PR DESCRIPTION
Fixes #319

### Description

When arriving on a docs page via search, Sphinx highlights matched words using the `.hll` class. The theme's existing `.hll` rule inside `pre` was being overridden by `pygments.css` which uses `.highlight .hll` with a bright yellow background (`#ffffcc`). This yellow is completely illegible against the dark code block background used by this theme.

The theme's `.hll` rule compiled to `pre .hll` which has lower CSS specificity than `pygments.css`'s `.highlight .hll`, so the yellow always on. Fix adds `.highlight .hll` outside the `pre` block with a readable semi-transparent teal color using the existing `$base16-base03` variable.

### AI usage
Claude helped in writing the description.

Screenshots :Highlighted lines show subtle teal, readable against dark code block.
<img width="1366" height="733" alt="highlight" src="https://github.com/user-attachments/assets/4ddfadd5-4874-461a-9753-59d7b690e4b6" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing in code blocks for better readability
  * Enhanced visual styling for syntax-highlighted code with refined color adjustments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wagtail/sphinx-wagtail-theme/pull/320?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes search-term highlights in code blocks becoming illegible because `pygments.css`'s `.highlight .hll` (two class selectors) overrides the theme's `pre .hll` (one class + one type selector) with a bright yellow background that is unreadable against the dark code block.

- Adds a new `.highlight .hll` rule at the file level, matching Pygments' specificity so the later-loaded theme CSS wins in the cascade, and sets a semi-transparent teal background via `color.adjust($base16-base03, $alpha: -0.4)`.
- The existing `pre .hll` rule inside the `pre` block is kept as a lower-specificity fallback for any `.hll` that appears outside a `.highlight` container.

<h3>Confidence Score: 5/5</h3>

The change is a targeted, additive CSS specificity fix with no behavioral side-effects outside of code block search highlights.

The single new rule correctly matches the specificity of pygments.css's .highlight .hll and relies on source order (theme after Pygments) to win the cascade — a well-established pattern in Sphinx themes. The color.adjust call is valid Dart Sass using the already-imported sass:color module and produces a 60%-opaque teal as described. The existing pre .hll fallback is harmless.

No files require special attention; the entire change is confined to a single additive CSS rule in sass/_component_pygments.scss.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| sass/_component_pygments.scss | Adds `.highlight .hll` rule with semi-transparent teal (`color.adjust($base16-base03, $alpha: -0.4)`) to override Pygments' yellow `.highlight .hll` via higher-specificity cascade; trailing whitespace introduced on the blank line inside `pre`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[".hll element in search-highlighted code block"] --> B{Which CSS rule applies?}
    B --> C["pygments.css .highlight .hll - specificity 0,2,0 - background: yellow #ffffcc"]
    B --> D["theme pre .hll - specificity 0,1,1 - background: base02"]
    B --> E["theme .highlight .hll NEW - specificity 0,2,0 - background: teal rgba 60%"]
    C -->|same specificity, source order decides| F{CSS load order}
    E -->|same specificity, source order decides| F
    D -->|lower specificity, always loses| G["overridden by pygments.css"]
    F -->|theme loaded after pygments.css| H["new .highlight .hll wins - readable teal"]
```

<sub>Reviews (2): Last reviewed commit: ["Update sass/\_component\_pygments.scss"](https://github.com/wagtail/sphinx-wagtail-theme/commit/ee5d384f30c6722b170ecc2f2afef404a92c054e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32448970)</sub>

<!-- /greptile_comment -->