### PR TITLE
Fix code highlight styles not being applied on Sphinx 9+

### DIFF
--- a/docs/examples/code-blocks.md
+++ b/docs/examples/code-blocks.md
@@ -110,3 +110,21 @@ exports.fizzbuzz = fizzbuzz;
 ```console
 $ ./manage.py runserver 0:8000
 ```
+
+## Emphasize lines
+
+Use the `emphasize-lines` option with the `code-block` directive to highlight specific lines.
+
+```{code-block} python
+:emphasize-lines: 3, 5, 7-8
+
+def fizzbuzz(number):
+    reply = ""
+    if number % 3 == 0:
+        reply += "Fizz"
+    if number % 5 == 0:
+        reply += "Buzz"
+    if not reply:
+        return number
+    return reply
+```

--- a/sphinx_wagtail_theme/layout.html
+++ b/sphinx_wagtail_theme/layout.html
@@ -35,7 +35,7 @@
     {#- Include stylesheets from sphinx (e.g. user custom css #}
     {%- for css in css_files %}
     {#- Block pygments css; we are manually including ours in theme.css instead #}
-    {%- if css not in ["_static/pygments.css"] %}
+    {%- if (css.filename or css) not in ["_static/pygments.css"] %}
       {%- if css|attr("filename") %}
       {{ css_tag(css) }}
       {%- else %}


### PR DESCRIPTION
<!-- For guidance on making a great pull request, be sure to check https://github.com/wagtail/wagtail/blob/main/.github/CONTRIBUTING.md -->


<!-- Insert the issue number that you're fixing here, if any -->
Fixes #319 where our pygments styles not being applied due to the built-in one taking precedence. We normally exclude the built-in `pygments.css` in favour of our own styles in `theme.css`. This was done by checking whether the CSS object matches `_static/pygments.css`.


### Description

<!-- Please describe the problem you're fixing. -->

In Sphinx >=1.8.0,<9.0, the CSS object uses the filename as its string representation (for compatibility with Sphinx<1.8.0 that uses plain strings for the css). In Sphinx 8, this string representation is deprecated in favour of using the `.filename` attribute of the CSS object. In Sphinx 9, this is removed entirely, which causes it to never match `_static/pygments.css`.

```
wagtail/venv/lib/python3.14/site-packages/sphinx_wagtail_theme/layout.html:150: RemovedInSphinx90Warning: The str interface for _CascadingStyleSheet objects is deprecated. Use css.filename instead.
  {% endblock -%}
done
```

### AI usage

<!-- Please give details of any AI assistance that has been used for this PR - including for writing this description - or "None" if no AI has been used. -->
Claude Code agent on VSCode with default settings was used to help confirm the issue and write the initial fix, but I ended up writing the final version which is much simpler.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stylesheet filtering in the theme's layout template to ensure proper CSS file inclusion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->